### PR TITLE
Convert 'tags' column values to JSON strings 

### DIFF
--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -206,6 +206,7 @@ class FMTMSplitter(object):
 
         # Add aoi to project_aoi table
         log.debug(f"Adding AOI to project_aoi table: {self.aoi.to_dict()}")
+        self.aoi["tags"] = self.aoi["tags"].apply(json.dumps)
         self.aoi.to_postgis(
             "project_aoi",
             conn,


### PR DESCRIPTION
# Update
Previously, tags obtained from the created data frame resulted into invalid json. 
This pull request addresses the issue of invalid json by converting it into json str before passing it to postgis.