### PR TITLE
Check the lines count excluding minor highway tags

### DIFF
--- a/fmtm_splitter/fmtm_algorithm.sql
+++ b/fmtm_splitter/fmtm_algorithm.sql
@@ -2,79 +2,84 @@ DROP TABLE IF EXISTS polygonsnocount;
 -- Create a new polygon layer of splits by lines
 
 DO $$
-DECLARE
+    DECLARE 
     lines_count INTEGER;
     num_buildings INTEGER;
 BEGIN
     -- Check if ways_line has any data
-    SELECT COUNT(*) INTO lines_count FROM ways_line;
-    
+    SELECT COUNT(*) INTO lines_count
+    FROM "ways_line" l
+    WHERE (
+        (l.tags->>'highway' IS NOT NULL AND 
+        l.tags->>'highway' NOT IN ('unclassified', 'residential', 'service', 'pedestrian', 'track', 'bus_guideway'))
+        OR l.tags->>'waterway' IS NOT NULL
+        OR l.tags->>'railway' IS NOT NULL
+    );
     IF lines_count > 0 THEN
-        CREATE TABLE polygonsnocount AS (
-
-            -- The Area of Interest provided by the person creating the project
-            WITH aoi AS (
-                SELECT * FROM "project_aoi"
+    CREATE TABLE polygonsnocount AS (
+        -- The Area of Interest provided by the person creating the project
+        WITH aoi AS (
+            SELECT * FROM "project_aoi"
+        )
+        -- Extract all lines to be used as splitlines from a table of lines
+        -- with the schema from Underpass (all tags as jsonb column called 'tags')
+        -- TODO: add polygons (closed ways in OSM) with a 'highway' tag;
+        -- some features such as roundabouts appear as polygons.
+        -- TODO: add waterway polygons; now a beach doesn't show up as a splitline.
+        -- TODO: these tags should come from another table rather than hardcoded
+        -- so that they're easily configured during project creation.
+        , splitlines AS (
+            SELECT ST_Intersection(a.geom, l.geom) AS geom
+            FROM aoi a
+            JOIN "ways_line" l ON ST_Intersects(a.geom, l.geom)
+            WHERE (
+                (l.tags->>'highway' IS NOT NULL AND 
+                l.tags->>'highway' NOT IN ('unclassified', 'residential', 'service', 'pedestrian', 'track', 'bus_guideway')) -- TODO: update(add/remove) this based on the requirements later
+                OR l.tags->>'waterway' IS NOT NULL
+                OR l.tags->>'railway' IS NOT NULL
             )
-            -- Extract all lines to be used as splitlines from a table of lines
-            -- with the schema from Underpass (all tags as jsonb column called 'tags')
-            -- TODO: add polygons (closed ways in OSM) with a 'highway' tag;
-            -- some features such as roundabouts appear as polygons.
-            -- TODO: add waterway polygons; now a beach doesn't show up as a splitline.
-            -- TODO: these tags should come from another table rather than hardcoded
-            -- so that they're easily configured during project creation.
-            , splitlines AS (
-                SELECT ST_Intersection(a.geom, l.geom) AS geom
-                FROM aoi a
-                JOIN "ways_line" l ON ST_Intersects(a.geom, l.geom)
-                WHERE (
-                    (l.tags->>'highway' IS NOT NULL AND 
-                    l.tags->>'highway' NOT IN ('unclassified', 'residential', 'service', 'pedestrian', 'track', 'bus_guideway')) -- TODO: update(add/remove) this based on the requirements later
-                    OR l.tags->>'waterway' IS NOT NULL
-                    OR l.tags->>'railway' IS NOT NULL
-                )
-            )
-                
-            --     SELECT * from lines_view l
-            --    WHERE (
-            --         (l.tags->>'highway' IS NOT NULL AND 
-            --         l.tags->>'highway' NOT IN ('unclassified', 'residential', 'service', 'pedestrian', 'track', 'bus_guideway'))
-            --         OR l.tags->>'waterway' IS NOT NULL
-            --         OR l.tags->>'railway' IS NOT NULL
-            --     )
-            -- )
-            -- Merge all lines, necessary so that the polygonize function works later
-            ,merged AS (
-                SELECT ST_LineMerge(ST_Union(splitlines.geom)) AS geom
-                FROM splitlines
-            )
-            -- Combine the boundary of the AOI with the splitlines
-            -- First extract the Area of Interest boundary as a line
-            ,boundary AS (
-                SELECT ST_Boundary(geom) AS geom
-                FROM aoi
-            )
-            -- Then combine it with the splitlines
-            ,comb AS (
-                SELECT ST_Union(boundary.geom, merged.geom) AS geom
-                FROM boundary, merged
-            )
-            -- TODO add closed ways from OSM to lines (roundabouts etc)
-            -- Create a polygon for each area enclosed by the splitlines
-            ,splitpolysnoindex AS (
-                SELECT (ST_Dump(ST_Polygonize(comb.geom))).geom as geom
-                FROM comb
-            )
-            -- Add an index column to the split polygons
-            ,splitpolygons AS(
-                SELECT
-                row_number () over () as polyid,
+        )
+            
+        --     SELECT * from lines_view l
+        --    WHERE (
+        --         (l.tags->>'highway' IS NOT NULL AND 
+        --         l.tags->>'highway' NOT IN ('unclassified', 'residential', 'service', 'pedestrian', 'track', 'bus_guideway'))
+        --         OR l.tags->>'waterway' IS NOT NULL
+        --         OR l.tags->>'railway' IS NOT NULL
+        --     )
+        -- )
+        -- Merge all lines, necessary so that the polygonize function works later
+        ,merged AS (
+            SELECT ST_LineMerge(ST_Union(splitlines.geom)) AS geom
+            FROM splitlines
+        )
+        -- Combine the boundary of the AOI with the splitlines
+        -- First extract the Area of Interest boundary as a line
+        ,boundary AS (
+            SELECT ST_Boundary(geom) AS geom
+            FROM aoi
+        )
+        -- Then combine it with the splitlines
+        ,comb AS (
+            SELECT ST_Union(boundary.geom, merged.geom) AS geom
+            FROM boundary, merged
+        )
+        -- TODO add closed ways from OSM to lines (roundabouts etc)
+        -- Create a polygon for each area enclosed by the splitlines
+        ,splitpolysnoindex AS (
+            SELECT (ST_Dump(ST_Polygonize(comb.geom))).geom as geom
+            FROM comb
+        )
+        -- Add an index column to the split polygons
+        ,splitpolygons AS(
+            SELECT
+            row_number () over () as polyid,
                 ST_Transform(spni.geom,4326)::geography AS geog,
-                spni.* 
-                from splitpolysnoindex spni
-            )
-            SELECT * FROM splitpolygons
-            );
+            spni.* 
+            from splitpolysnoindex spni
+        )
+        SELECT * FROM splitpolygons
+    );
     ELSE
         -- Calculate number of buildings per cluster
         CREATE TABLE polygonsnocount AS (


### PR DESCRIPTION
## Issue:
- fix #35 
## Updates:
- Check the lines count filtering minor highway tags and allow splitting using those linear features only if there are linear features which avoids failure of splitting if no major linear feature are present in the data extracts
- Allow clustering to split the AOI when there are no linear features