### PR TITLE
Added data extracts to avoid creating tasks with no features

### DIFF
--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -160,6 +160,8 @@ class FMTMSplitter(object):
 
         Args:
             meters (int):  The size of each task square in meters.
+            extract_geojson (dict, FeatureCollection): an OSM extract geojson,
+                containing building polygons, or linestrings.
 
         Returns:
             data (FeatureCollection): A multipolygon of all the task boundaries.
@@ -404,6 +406,11 @@ def split_by_square(
             GeoJSON string, or FeatureCollection object.
         meters(str, optional): Specify the square size for the grid.
             Defaults to 100m grid.
+        osm_extract (str, FeatureCollection): an OSM extract geojson,
+            containing building polygons, or linestrings.
+            Optional param, if not included an extract is generated for you.
+            It is recommended to leave this param as default, unless you know
+            what you are doing.
         outfile(str): Output to a GeoJSON file on disk.
 
     Returns:

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -64,15 +64,11 @@ def test_init_splitter_types(aoi_json):
 def test_split_by_square_with_dict(aoi_json, extract_json):
     """Test divide by square from geojson dict types."""
     features = split_by_square(
-        aoi_json.get("features")[0],
-        meters=50,
-        osm_extract=extract_json
+        aoi_json.get("features")[0], meters=50, osm_extract=extract_json
     )
     assert len(features.get("features")) == 50
     features = split_by_square(
-        aoi_json.get("features")[0].get("geometry"),
-        meters=50,
-        osm_extract=extract_json
+        aoi_json.get("features")[0].get("geometry"), meters=50, osm_extract=extract_json
     )
     assert len(features.get("features")) == 50
 
@@ -81,23 +77,21 @@ def test_split_by_square_with_str(aoi_json, extract_json):
     """Test divide by square from geojson str and file."""
     # GeoJSON Dumps
     features = split_by_square(
-        geojson.dumps(aoi_json.get("features")[0]),
-        meters=50,
-        osm_extract=extract_json
+        geojson.dumps(aoi_json.get("features")[0]), meters=50, osm_extract=extract_json
     )
     assert len(features.get("features")) == 50
     # JSON Dumps
     features = split_by_square(
         json.dumps(aoi_json.get("features")[0].get("geometry")),
         meters=50,
-        osm_extract=extract_json
+        osm_extract=extract_json,
     )
     assert len(features.get("features")) == 50
     # File
     features = split_by_square(
         "tests/testdata/kathmandu.geojson",
         meters=100,
-        osm_extract="tests/testdata/kathmandu_extract.geojson"
+        osm_extract="tests/testdata/kathmandu_extract.geojson",
     )
     assert len(features.get("features")) == 15
 
@@ -121,7 +115,7 @@ def test_split_by_square_with_file_output():
     assert len(output_geojson.get("features")) == 50
 
 
-def test_split_by_square_with_multigeom_input(aoi_multi_json,extract_json):
+def test_split_by_square_with_multigeom_input(aoi_multi_json, extract_json):
     """Test divide by square from geojson dict types."""
     file_name = uuid4()
     outfile = Path(__file__).parent.parent / f"{file_name}.geojson"
@@ -219,7 +213,18 @@ def test_split_by_square_cli():
     outfile = Path(__file__).parent.parent / f"{uuid4()}.geojson"
 
     try:
-        main(["--boundary", str(infile), "--meters", "100", "--extract", str(extract_geojson), "--outfile", str(outfile)])
+        main(
+            [
+                "--boundary",
+                str(infile),
+                "--meters",
+                "100",
+                "--extract",
+                str(extract_geojson),
+                "--outfile",
+                str(outfile),
+            ]
+        )
     except SystemExit:
         pass
 

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -61,38 +61,43 @@ def test_init_splitter_types(aoi_json):
     assert str(error.value) == "The input AOI cannot contain multiple geometries."
 
 
-def test_split_by_square_with_dict(aoi_json):
+def test_split_by_square_with_dict(aoi_json, extract_json):
     """Test divide by square from geojson dict types."""
     features = split_by_square(
         aoi_json.get("features")[0],
         meters=50,
+        osm_extract=extract_json
     )
-    assert len(features.get("features")) == 54
+    assert len(features.get("features")) == 50
     features = split_by_square(
         aoi_json.get("features")[0].get("geometry"),
         meters=50,
+        osm_extract=extract_json
     )
-    assert len(features.get("features")) == 54
+    assert len(features.get("features")) == 50
 
 
-def test_split_by_square_with_str(aoi_json):
+def test_split_by_square_with_str(aoi_json, extract_json):
     """Test divide by square from geojson str and file."""
     # GeoJSON Dumps
     features = split_by_square(
         geojson.dumps(aoi_json.get("features")[0]),
         meters=50,
+        osm_extract=extract_json
     )
-    assert len(features.get("features")) == 54
+    assert len(features.get("features")) == 50
     # JSON Dumps
     features = split_by_square(
         json.dumps(aoi_json.get("features")[0].get("geometry")),
         meters=50,
+        osm_extract=extract_json
     )
-    assert len(features.get("features")) == 54
+    assert len(features.get("features")) == 50
     # File
     features = split_by_square(
         "tests/testdata/kathmandu.geojson",
         meters=100,
+        osm_extract="tests/testdata/kathmandu_extract.geojson"
     )
     assert len(features.get("features")) == 15
 
@@ -105,26 +110,28 @@ def test_split_by_square_with_file_output():
     outfile = Path(__file__).parent.parent / f"{uuid4()}.geojson"
     features = split_by_square(
         "tests/testdata/kathmandu.geojson",
+        osm_extract="tests/testdata/kathmandu_extract.geojson",
         meters=50,
         outfile=str(outfile),
     )
-    assert len(features.get("features")) == 54
+    assert len(features.get("features")) == 50
     # Also check output file
     with open(outfile, "r") as jsonfile:
         output_geojson = geojson.load(jsonfile)
-    assert len(output_geojson.get("features")) == 54
+    assert len(output_geojson.get("features")) == 50
 
 
-def test_split_by_square_with_multigeom_input(aoi_multi_json):
+def test_split_by_square_with_multigeom_input(aoi_multi_json,extract_json):
     """Test divide by square from geojson dict types."""
     file_name = uuid4()
     outfile = Path(__file__).parent.parent / f"{file_name}.geojson"
     features = split_by_square(
         aoi_multi_json,
         meters=50,
+        osm_extract=extract_json,
         outfile=str(outfile),
     )
-    assert len(features.get("features", [])) == 60
+    assert len(features.get("features", [])) == 50
     for index in [0, 1, 2, 3]:
         assert Path(f"{Path(outfile).stem}_{index}.geojson)").exists()
 
@@ -208,10 +215,11 @@ def test_cli_help(capsys):
 def test_split_by_square_cli():
     """Test split by square works via CLI."""
     infile = Path(__file__).parent / "testdata" / "kathmandu.geojson"
+    extract_geojson = Path(__file__).parent / "testdata" / "kathmandu_extract.geojson"
     outfile = Path(__file__).parent.parent / f"{uuid4()}.geojson"
 
     try:
-        main(["--boundary", str(infile), "--meters", "100", "--outfile", str(outfile)])
+        main(["--boundary", str(infile), "--meters", "100", "--extract", str(extract_geojson), "--outfile", str(outfile)])
     except SystemExit:
         pass
 
@@ -226,6 +234,7 @@ def test_split_by_features_cli():
     infile = Path(__file__).parent / "testdata" / "kathmandu.geojson"
     outfile = Path(__file__).parent.parent / f"{uuid4()}.geojson"
     split_geojson = Path(__file__).parent / "testdata" / "kathmandu_split.geojson"
+    extract_geojson = Path(__file__).parent / "testdata" / "kathmandu_extract.geojson"
 
     try:
         main(
@@ -234,6 +243,8 @@ def test_split_by_features_cli():
                 str(infile),
                 "--source",
                 str(split_geojson),
+                "--extract",
+                str(extract_geojson),
                 "--outfile",
                 str(outfile),
             ]


### PR DESCRIPTION
## Issue:
- fix #37 

## Updates:
This PR now avoids creating tasks with no features in them when the AOI is splitted using the `split_by_square` algorithm. 

- Data extracts are now passed to the logic in order to check if a task has any features in it or not. In case a task does not have osm features inside it , it won't be appended to the list of tasks generated by the algorithm.