### PR TITLE
If --extract is used, it needs to be passed to split_by_square()

### DIFF
--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -787,7 +787,7 @@ be either the data extract used by the XLSForm, or a postgresql database.
                 meters=args.meters,
                 osm_extract=data,
                 outfile=args.outfile,
-                )
+            )
         else:
             split_by_square(
                 args.boundary,

--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -778,11 +778,22 @@ be either the data extract used by the XLSForm, or a postgresql database.
         raise ValueError(err)
 
     if args.meters:
-        split_by_square(
-            args.boundary,
-            meters=args.meters,
-            outfile=args.outfile,
-        )
+        if args.extract:
+            file = open(args.extract, "r")
+            data = geojson.load(file)
+            file.close()
+            split_by_square(
+                args.boundary,
+                meters=args.meters,
+                osm_extract=data,
+                outfile=args.outfile,
+                )
+        else:
+            split_by_square(
+                args.boundary,
+                meters=args.meters,
+                outfile=args.outfile,
+            )
     elif args.number:
         split_by_sql(
             args.boundary,


### PR DESCRIPTION
Currently if using the --extract option to fmtm-splitter on the command line it downloads the data extracts anyway because this value is not passed to split_by_square(). This PR passes that option in if it's specified.