### PR TITLE
Fix : remove osm-extracts from split by square

### DIFF
--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -194,9 +194,9 @@ class FMTMSplitter(object):
                 )
                 clipped_polygon = grid_polygon.intersection(self.aoi)
                 if extract_geoms:
-                        # Check if any extract geometry is within the clipped grid
-                        if any(geom.within(clipped_polygon) for geom in extract_geoms):
-                            polygons.append(clipped_polygon)
+                    # Check if any extract geometry is within the clipped grid
+                    if any(geom.within(clipped_polygon) for geom in extract_geoms):
+                        polygons.append(clipped_polygon)
                 else:
                     polygons.append(clipped_polygon)
 
@@ -425,7 +425,7 @@ def split_by_square(
 
     if osm_extract:
         extract_geojson = FMTMSplitter.input_to_geojson(osm_extract)
-    
+
     # Handle multiple geometries passed
     if len(feat_array := aoi_featcol.get("features", [])) > 1:
         features = []


### PR DESCRIPTION
## Updates:

This PR updates the function splitting by square by removing requirement to download osm features but allowing custom features to pass to the function.

## Issue:
- #44 

## Response:

Without osm-features:
![image](https://github.com/user-attachments/assets/fc5b4820-df79-4502-94bd-48c0f619a66d)

with custom features:
![image](https://github.com/user-attachments/assets/efab92b6-abd7-4063-ac54-da8743249c08)

