### PR TITLE
Use geodesic conversion of meters, avoid empty polygon

### DIFF
--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -748,6 +748,7 @@ be either the data extract used by the XLSForm, or a postgresql database.
         "--meters",
         nargs="?",
         const=50,
+        type=int,
         help="Size in meters if using square splitting",
     )
     parser.add_argument(

--- a/fmtm_splitter/splitter.py
+++ b/fmtm_splitter/splitter.py
@@ -155,11 +155,14 @@ class FMTMSplitter(object):
     def meters_to_degrees(
         self, meters: float, reference_lat: float
     ) -> Tuple[float, float]:
-        """Converts meters to degrees at a given latitude using WGS84 ellipsoidal calculations.
+        """Converts meters to degrees at a given latitude.
+
+        Using WGS84 ellipsoidal calculations.
 
         Args:
             meters (float): The distance in meters to convert.
-            reference_lat (float): The latitude at which to perform the conversion (in degrees).
+            reference_lat (float): The latitude at which to ,
+            perform the conversion (in degrees).
 
         Returns:
             Tuple[float, float]: Degree values for latitude and longitude.
@@ -176,15 +179,15 @@ class FMTMSplitter(object):
 
         # Applying formula
         e2 = (2 * f) - (f**2)  # Eccentricity squared
-        N = a / math.sqrt(
+        n = a / math.sqrt(
             1 - e2 * math.sin(lat_rad) ** 2
         )  # Radius of curvature in the prime vertical
-        M = (
+        m = (
             a * (1 - e2) / (1 - e2 * math.sin(lat_rad) ** 2) ** (3 / 2)
         )  # Radius of curvature in the meridian
 
-        lat_deg_change = meters / M  # Latitude change in degrees
-        lon_deg_change = meters / (N * math.cos(lat_rad))  # Longitude change in degrees
+        lat_deg_change = meters / m  # Latitude change in degrees
+        lon_deg_change = meters / (n * math.cos(lat_rad))  # Longitude change in degrees
 
         # Convert changes to degrees by dividing by radians to degrees
         lat_deg_change = math.degrees(lat_deg_change)

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -66,11 +66,11 @@ def test_split_by_square_with_dict(aoi_json, extract_json):
     features = split_by_square(
         aoi_json.get("features")[0], meters=50, osm_extract=extract_json
     )
-    assert len(features.get("features")) == 50
+    assert len(features.get("features")) == 60
     features = split_by_square(
         aoi_json.get("features")[0].get("geometry"), meters=50, osm_extract=extract_json
     )
-    assert len(features.get("features")) == 50
+    assert len(features.get("features")) == 60
 
 
 def test_split_by_square_with_str(aoi_json, extract_json):
@@ -79,21 +79,21 @@ def test_split_by_square_with_str(aoi_json, extract_json):
     features = split_by_square(
         geojson.dumps(aoi_json.get("features")[0]), meters=50, osm_extract=extract_json
     )
-    assert len(features.get("features")) == 50
+    assert len(features.get("features")) == 60
     # JSON Dumps
     features = split_by_square(
         json.dumps(aoi_json.get("features")[0].get("geometry")),
         meters=50,
         osm_extract=extract_json,
     )
-    assert len(features.get("features")) == 50
+    assert len(features.get("features")) == 60
     # File
     features = split_by_square(
         "tests/testdata/kathmandu.geojson",
         meters=100,
         osm_extract="tests/testdata/kathmandu_extract.geojson",
     )
-    assert len(features.get("features")) == 15
+    assert len(features.get("features")) == 20
 
 
 def test_split_by_square_with_file_output():
@@ -108,11 +108,11 @@ def test_split_by_square_with_file_output():
         meters=50,
         outfile=str(outfile),
     )
-    assert len(features.get("features")) == 50
+    assert len(features.get("features")) == 60
     # Also check output file
     with open(outfile, "r") as jsonfile:
         output_geojson = geojson.load(jsonfile)
-    assert len(output_geojson.get("features")) == 50
+    assert len(output_geojson.get("features")) == 60
 
 
 def test_split_by_square_with_multigeom_input(aoi_multi_json, extract_json):
@@ -125,7 +125,7 @@ def test_split_by_square_with_multigeom_input(aoi_multi_json, extract_json):
         osm_extract=extract_json,
         outfile=str(outfile),
     )
-    assert len(features.get("features", [])) == 50
+    assert len(features.get("features", [])) == 80
     for index in [0, 1, 2, 3]:
         assert Path(f"{Path(outfile).stem}_{index}.geojson)").exists()
 
@@ -231,7 +231,7 @@ def test_split_by_square_cli():
     with open(outfile, "r") as jsonfile:
         output_geojson = geojson.load(jsonfile)
 
-    assert len(output_geojson.get("features")) == 15
+    assert len(output_geojson.get("features")) == 20
 
 
 def test_split_by_features_cli():


### PR DESCRIPTION
## Description:
This PR uses geodesic conversion formula to convert meters to degrees (lat, lon)  instead of hardcoded degree to convert meters to degree. Additionally, it fixes the issue of appending empty polygons to geojson output.

## Updates:
Geodesic conversion includes the use of WGS:84 Ellipsoidal parameters such as :
```
- lat_rad: reference latitude in radian
- semi major axis : a = 6378137.0 m
- flattening factor : f = 1 / 298.257223563
- squared eccentricity (e2) : 2 f - (f ^ 2)
- radius of curvature in prime vertical (N) : a /sqrt(1 - e2 * sin(lat_rad)^2)
- radius of curvature in the meridian (M) : a * (1 - e2) / (1 - e2 * sin(lat_rad)^2)^(3 / 2)
```
![image](https://github.com/user-attachments/assets/3e3d8b21-3c90-4b22-82bd-17002da04023)

## Issue:
- #42

